### PR TITLE
[Feat] 토큰 갱신

### DIFF
--- a/server/src/main/java/com/dlteam2/server/User/Controller/TokenController.java
+++ b/server/src/main/java/com/dlteam2/server/User/Controller/TokenController.java
@@ -25,7 +25,7 @@ public class TokenController {
         this.userService = userService;
     }
 
-    @PostMapping("refresh")
+    @PostMapping("/refresh")
     public ResponseDTO.DataResponse accessTokenRefresh(@RequestBody JSONObject data){
         try{
             String refreshToken = data.get("refresh_token").toString();

--- a/server/src/main/java/com/dlteam2/server/User/Controller/TokenController.java
+++ b/server/src/main/java/com/dlteam2/server/User/Controller/TokenController.java
@@ -1,0 +1,43 @@
+package com.dlteam2.server.User.Controller;
+
+import com.dlteam2.server.Common.ResponseDTO;
+import com.dlteam2.server.Exception.ApiException;
+import com.dlteam2.server.Exception.ExceptionEnum;
+import com.dlteam2.server.User.Service.TokenService;
+import com.dlteam2.server.User.Service.UserService;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tokens")
+public class TokenController {
+    private final TokenService tokenService;
+    private final UserService userService;
+
+    @Autowired
+    public TokenController(TokenService tokenService, UserService userService) {
+        this.tokenService = tokenService;
+        this.userService = userService;
+    }
+
+    @PostMapping("refresh")
+    public ResponseDTO.DataResponse accessTokenRefresh(@RequestBody JSONObject data){
+        try{
+            String refreshToken = data.get("refresh_token").toString();
+            String accessToken = tokenService.refreshAccessToken(refreshToken);
+            JSONObject result = new JSONObject();
+            result.put("access_token", accessToken);
+            return ResponseDTO.DataResponse.builder()
+                    .code(HttpStatus.OK.value())
+                    .message(HttpStatus.OK.getReasonPhrase())
+                    .data(result).build();
+        }catch(Exception e){
+            throw new ApiException(ExceptionEnum.REQUEST_VALUE_INVALID);
+        }
+    }
+}

--- a/server/src/main/java/com/dlteam2/server/User/Controller/UserController.java
+++ b/server/src/main/java/com/dlteam2/server/User/Controller/UserController.java
@@ -4,6 +4,7 @@ import com.dlteam2.server.Common.ResponseDTO;
 import com.dlteam2.server.Exception.ApiException;
 import com.dlteam2.server.Exception.ExceptionEnum;
 import com.dlteam2.server.User.DTO.ResponseDTO.UserInfoResponseDTO;
+import com.dlteam2.server.User.Service.TokenService;
 import com.dlteam2.server.User.Service.UserService;
 import net.bytebuddy.implementation.bytecode.Throw;
 import org.json.simple.JSONObject;
@@ -15,9 +16,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+    private final TokenService tokenService;
     @Autowired
-    public UserController(UserService userService){
+    public UserController(UserService userService, TokenService tokenService){
         this.userService = userService;
+        this.tokenService = tokenService;
     }
 
     @PostMapping("/search/email")
@@ -44,7 +47,7 @@ public class UserController {
 
     @GetMapping ("/info")
     public ResponseDTO.ObjectDataResponse userInfo(@RequestHeader("Authorization") String token){
-        String id = userService.getUserId(token);
+        String id = tokenService.getUserId(token);
         UserInfoResponseDTO resultData = userService.getUserInfo(id);
 
         JSONObject result = new JSONObject();
@@ -58,7 +61,7 @@ public class UserController {
 
     @PatchMapping("/info/update/mobile")
     public ResponseDTO.DataResponse updateMobile(@RequestHeader("Authorization") String token, @RequestBody JSONObject data){
-        String id = userService.getUserId(token);
+        String id = tokenService.getUserId(token);
         String mobile = data.get("mobile").toString();
         JSONObject result = new JSONObject();
         if(userService.updateMobile(id, mobile)){
@@ -74,7 +77,7 @@ public class UserController {
 
     @PatchMapping("/info/update/email")
     public ResponseDTO.DataResponse updateEmail(@RequestHeader("Authorization") String token, @RequestBody JSONObject data){
-        String id = userService.getUserId(token);
+        String id = tokenService.getUserId(token);
         String email = data.get("email").toString();
         JSONObject result = new JSONObject();
         if(userService.updateEmail(id, email)){
@@ -90,7 +93,7 @@ public class UserController {
 
     @PatchMapping("/info/update/password")
     public ResponseDTO.DataResponse updatePassword(@RequestHeader("Authorization") String token, @RequestBody JSONObject data){
-        String id = userService.getUserId(token);
+        String id = tokenService.getUserId(token);
         String password = data.get("password").toString();
         JSONObject result = new JSONObject();
         if(userService.updatePassword(id, password)){

--- a/server/src/main/java/com/dlteam2/server/User/DTO/RefreshTokenDTO.java
+++ b/server/src/main/java/com/dlteam2/server/User/DTO/RefreshTokenDTO.java
@@ -14,13 +14,15 @@ import java.util.UUID;
 public class RefreshTokenDTO {
     private UUID id;
     private String userId;
+    private String token;
     private Date iat;
     private boolean exp;
 
     @Builder
-    public RefreshTokenDTO(UUID id, String userId, Date iat, boolean exp) {
+    public RefreshTokenDTO(UUID id, String userId, String token, Date iat, boolean exp) {
         this.id = id;
         this.userId = userId;
+        this.token = token;
         this.iat = iat;
         this.exp = exp;
     }

--- a/server/src/main/java/com/dlteam2/server/User/Entity/RefreshToken.java
+++ b/server/src/main/java/com/dlteam2/server/User/Entity/RefreshToken.java
@@ -15,12 +15,15 @@ import java.util.Date;
 public class RefreshToken {
     @EmbeddedId
     private RefreshTokenId id;
+    private String token;
     private Date iat; //발행일
     private boolean exp;
 
+
     @Builder
-    public RefreshToken(RefreshTokenId id, Date iat, boolean exp) {
+    public RefreshToken(RefreshTokenId id, String token, Date iat, boolean exp) {
         this.id = id;
+        this.token = token;
         this.iat = iat;
         this.exp = exp;
     }

--- a/server/src/main/java/com/dlteam2/server/User/Entity/RefreshTokenId.java
+++ b/server/src/main/java/com/dlteam2/server/User/Entity/RefreshTokenId.java
@@ -5,10 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Embeddable;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 import java.io.Serializable;
+import java.util.UUID;
 
 @Embeddable
 @Getter
@@ -17,11 +16,11 @@ public class RefreshTokenId implements Serializable {
     @ManyToOne
     @JoinColumn(name="user_id", referencedColumnName = "id")
     private User user;
-    private String id;
+    private UUID id;
 
     @Builder
-    public RefreshTokenId(User user, String id) {
-        this.user = user;
+    public RefreshTokenId(User user, UUID id) {
         this.id = id;
+        this.user = user;
     }
 }

--- a/server/src/main/java/com/dlteam2/server/User/Repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/dlteam2/server/User/Repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.dlteam2.server.User.Repository;
+
+import com.dlteam2.server.User.Entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findTopByTokenOrderByIatDesc(String Token);
+}

--- a/server/src/main/java/com/dlteam2/server/User/Repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/dlteam2/server/User/Repository/RefreshTokenRepository.java
@@ -5,8 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
-    Optional<RefreshToken> findTopByTokenOrderByIatDesc(String Token);
+    Optional<RefreshToken> findTopByIdUserIdOrderByIatDesc(UUID userId);
 }

--- a/server/src/main/java/com/dlteam2/server/User/Service/TokenService.java
+++ b/server/src/main/java/com/dlteam2/server/User/Service/TokenService.java
@@ -1,0 +1,10 @@
+package com.dlteam2.server.User.Service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface TokenService {
+    String getUserId(String token);
+    String generateAccessToken(String id);
+    String refreshAccessToken(String token);
+}

--- a/server/src/main/java/com/dlteam2/server/User/Service/TokenServiceImpl.java
+++ b/server/src/main/java/com/dlteam2/server/User/Service/TokenServiceImpl.java
@@ -42,7 +42,7 @@ public class TokenServiceImpl implements TokenService{
     @Override
     public String refreshAccessToken(String token) {
         String userId = getUserId(token);
-        Optional<RefreshToken> latestRefreshToken = refreshTokenRepository.findTopByTokenOrderByIatDesc(token);
+        Optional<RefreshToken> latestRefreshToken = refreshTokenRepository.findTopByIdUserIdOrderByIatDesc(UUID.fromString(userId));
         if(latestRefreshToken.isPresent() && latestRefreshToken.get().getId().getUser().getId().equals(UUID.fromString(userId))){
             if(!latestRefreshToken.get().isExp()){
                 String refreshAccessToken = generateAccessToken(userId);

--- a/server/src/main/java/com/dlteam2/server/User/Service/TokenServiceImpl.java
+++ b/server/src/main/java/com/dlteam2/server/User/Service/TokenServiceImpl.java
@@ -1,0 +1,58 @@
+package com.dlteam2.server.User.Service;
+
+import com.auth0.jwt.JWT;
+import com.dlteam2.server.Exception.ApiException;
+import com.dlteam2.server.Exception.ExceptionEnum;
+import com.dlteam2.server.User.Entity.RefreshToken;
+import com.dlteam2.server.User.Repository.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class TokenServiceImpl implements TokenService{
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    public TokenServiceImpl(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Override
+    public String getUserId(String token) {
+        try {
+            token = token.replaceFirst("Bearer ","");
+            String id = JWT.decode(token)
+                    .getClaim("id")
+                    .asString();
+            return id;
+        } catch(Exception e){
+            throw new ApiException(ExceptionEnum.INVALID_TOKEN);
+        }
+    }
+
+    //TODO - access token 생성
+    @Override
+    public String generateAccessToken(String id) {
+        return null;
+    }
+
+    @Override
+    public String refreshAccessToken(String token) {
+        String userId = getUserId(token);
+        Optional<RefreshToken> latestRefreshToken = refreshTokenRepository.findTopByTokenOrderByIatDesc(token);
+        if(latestRefreshToken.isPresent() && latestRefreshToken.get().getId().getUser().getId().equals(UUID.fromString(userId))){
+            if(!latestRefreshToken.get().isExp()){
+                String refreshAccessToken = generateAccessToken(userId);
+                return refreshAccessToken;
+            }else{
+                throw new ApiException(ExceptionEnum.EXPIRED_TOKEN);
+            }
+        }else{
+            throw new ApiException(ExceptionEnum.REQUEST_VALUE_INVALID);
+        }
+    }
+
+}

--- a/server/src/main/java/com/dlteam2/server/User/Service/UserService.java
+++ b/server/src/main/java/com/dlteam2/server/User/Service/UserService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 public interface UserService {
     String findIdByMobile(String mobile);
     String findEmail(String id);
-    String getUserId(String token);
     UserInfoResponseDTO getUserInfo(String id);
 
     boolean updateMobile(String id, String mobile);

--- a/server/src/main/java/com/dlteam2/server/User/Service/UserServiceImpl.java
+++ b/server/src/main/java/com/dlteam2/server/User/Service/UserServiceImpl.java
@@ -51,18 +51,6 @@ public class UserServiceImpl implements UserService{
         }
     }
 
-    @Override
-    public String getUserId(String token) {
-        try {
-            token = token.replaceFirst("Bearer ","");
-            String id = JWT.decode(token)
-                    .getClaim("id")
-                    .asString();
-            return id;
-        } catch(Exception e){
-            throw new ApiException(ExceptionEnum.INVALID_TOKEN);
-        }
-    }
 
     @Override
     public UserInfoResponseDTO getUserInfo(String id) {
@@ -125,6 +113,7 @@ public class UserServiceImpl implements UserService{
         return false;
     }
 
+    //TODO - 비밀번호 암호화
     private String EncryptPassword(String password) {
         //<---패스워드 암호화 로직 구현하기--->
         return password;

--- a/server/src/test/java/com/dlteam2/server/Common/ControllerTest.java
+++ b/server/src/test/java/com/dlteam2/server/Common/ControllerTest.java
@@ -1,6 +1,7 @@
 package com.dlteam2.server.Common;
 
 import com.dlteam2.server.User.Controller.UserController;
+import com.dlteam2.server.User.Service.TokenServiceImpl;
 import com.dlteam2.server.User.Service.UserServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,5 +25,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected UserServiceImpl userService;
+    @MockBean
+    protected TokenServiceImpl tokenService;
 
 }

--- a/server/src/test/java/com/dlteam2/server/Common/ControllerTest.java
+++ b/server/src/test/java/com/dlteam2/server/Common/ControllerTest.java
@@ -1,5 +1,6 @@
 package com.dlteam2.server.Common;
 
+import com.dlteam2.server.User.Controller.TokenController;
 import com.dlteam2.server.User.Controller.UserController;
 import com.dlteam2.server.User.Service.TokenServiceImpl;
 import com.dlteam2.server.User.Service.UserServiceImpl;
@@ -12,7 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest({
-        UserController.class
+        UserController.class,
+        TokenController.class
 })
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")

--- a/server/src/test/java/com/dlteam2/server/User/Controller/TokenControllerTest.java
+++ b/server/src/test/java/com/dlteam2/server/User/Controller/TokenControllerTest.java
@@ -1,0 +1,37 @@
+package com.dlteam2.server.User.Controller;
+
+import com.dlteam2.server.Common.Constants;
+import com.dlteam2.server.Common.ControllerTest;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class TokenControllerTest extends ControllerTest {
+
+    @DisplayName("access token 갱신 테스트")
+    @Test
+    @WithMockUser("user")
+    void refreshAccessTokenTest() throws Exception{
+        String tmpToken = "Bearer tmp";
+        given(tokenService.refreshAccessToken(tmpToken)).willReturn(Constants.test_user_1_token);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("refresh_token", tmpToken);
+
+        mockMvc.perform(post("/tokens/refresh")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(jsonObject)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.access_token").value(Constants.test_user_1_token));
+
+    }
+}

--- a/server/src/test/java/com/dlteam2/server/User/Controller/UserControllerTest.java
+++ b/server/src/test/java/com/dlteam2/server/User/Controller/UserControllerTest.java
@@ -47,7 +47,7 @@ class UserControllerTest extends ControllerTest {
     @Test
     @WithMockUser("user")
     void getUserInfo() throws Exception{
-        given(userService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
+        given(tokenService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
         given(userService.getUserInfo(Constants.test_user_1_id)).willReturn(UserInfoResponseDTO.builder()
                 .loginInfo(List.of(UserInfoResponseDTO.LoginInfo.builder()
                         .loginType(LoginType.BASIC.name())
@@ -69,7 +69,7 @@ class UserControllerTest extends ControllerTest {
     @Test
     @WithMockUser("user")
     void updateMobile() throws Exception{
-        given(userService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
+        given(tokenService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
         given(userService.updateMobile(Constants.test_user_1_id, Constants.test_user_1_mobile)).willReturn(true);
 
         JSONObject jsonObject = new JSONObject();
@@ -89,7 +89,7 @@ class UserControllerTest extends ControllerTest {
     @Test
     @WithMockUser("user")
     void updateEmail() throws Exception{
-        given(userService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
+        given(tokenService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
         given(userService.updateEmail(Constants.test_user_1_id, Constants.test_user_1_email)).willReturn(true);
 
         JSONObject jsonObject = new JSONObject();
@@ -109,7 +109,7 @@ class UserControllerTest extends ControllerTest {
     @Test
     @WithMockUser("user")
     void updatePassword() throws Exception{
-        given(userService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
+        given(tokenService.getUserId(Constants.test_user_1_token)).willReturn(Constants.test_user_1_id);
         given(userService.updatePassword(Constants.test_user_1_id, Constants.test_user_1_password)).willReturn(true);
 
         JSONObject jsonObject = new JSONObject();

--- a/server/src/test/java/com/dlteam2/server/User/Repository/RefreshTokenRepositoryTest.java
+++ b/server/src/test/java/com/dlteam2/server/User/Repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.dlteam2.server.User.Repository;
+
+import com.dlteam2.server.Common.Constants;
+import com.dlteam2.server.Common.RepositoryTest;
+import com.dlteam2.server.User.Entity.RefreshToken;
+import com.dlteam2.server.User.Entity.RefreshTokenId;
+import com.dlteam2.server.User.Entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RefreshTokenRepositoryTest extends RepositoryTest {
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("발행일 순으로 정렬하여 가장 최근의 토큰값 하나만 받아오기")
+    @Test
+    void findTopByTokenOrderyIatDescTest(){
+        Calendar cal = Calendar.getInstance();
+        User user = User.builder().build();
+        user = userRepository.save(user);
+        RefreshToken refreshToken1 = RefreshToken.builder()
+                        .id(RefreshTokenId.builder().user(user).id(UUID.randomUUID()).build())
+                        .token(Constants.test_user_1_token)
+                        .iat(new Date(cal.getTimeInMillis()))
+                        .exp(false).build();
+        Calendar cal2 = Calendar.getInstance();
+        cal2.add(Calendar.DATE, -3);
+        refreshToken1 = refreshTokenRepository.save(refreshToken1);
+        RefreshToken refreshToken2 = RefreshToken.builder()
+                .id(RefreshTokenId.builder().user(user).id(UUID.randomUUID()).build())
+                .token(Constants.test_user_1_token)
+                .iat(new Date(cal2.getTimeInMillis()))
+                .exp(false).build();
+        refreshToken2 = refreshTokenRepository.save(refreshToken2);
+        Optional<RefreshToken> result = refreshTokenRepository.findTopByIdUserIdOrderByIatDesc(user.getId());
+        assertThat(result.get().getId().getUser().getId().toString()).isEqualTo(user.getId().toString());
+        assertThat(result.get().getIat()).isEqualTo(refreshToken1.getIat());
+    }
+}

--- a/server/src/test/java/com/dlteam2/server/User/Service/TokenServiceImplTest.java
+++ b/server/src/test/java/com/dlteam2/server/User/Service/TokenServiceImplTest.java
@@ -1,0 +1,44 @@
+package com.dlteam2.server.User.Service;
+
+import com.dlteam2.server.Common.Constants;
+import com.dlteam2.server.Common.ServiceTest;
+import com.dlteam2.server.User.Entity.RefreshToken;
+import com.dlteam2.server.User.Entity.RefreshTokenId;
+import com.dlteam2.server.User.Entity.User;
+import com.dlteam2.server.User.Repository.RefreshTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+public class TokenServiceImplTest extends ServiceTest {
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private TokenServiceImpl tokenService;
+
+    //TODO - 나머지 로직 개발 후에
+//    @DisplayName("access token 재생성")
+//    @Test
+//    void refreshAccessTokenTest(){
+//        String tmpToken = "Bearer tmp";
+//        RefreshToken refreshToken = RefreshToken.builder().build();
+//        when(refreshTokenRepository.findTopByIdUserIdOrderByIatDesc(UUID.fromString(Constants.test_user_1_id))).thenReturn(Optional.of(refreshToken));
+//        when(tokenService.getUserId(tmpToken)).thenReturn(Constants.test_user_1_id);
+//        when(tokenService.generateAccessToken(Constants.test_user_1_id)).thenReturn(Constants.test_user_1_token);
+//
+//        assertThat(tokenService.refreshAccessToken(tmpToken)).isEqualTo(null);
+//
+//    }
+}

--- a/server/src/test/java/com/dlteam2/server/User/Service/UserServiceImplTest.java
+++ b/server/src/test/java/com/dlteam2/server/User/Service/UserServiceImplTest.java
@@ -40,6 +40,8 @@ class UserServiceImplTest extends ServiceTest {
 
     @InjectMocks
     private UserServiceImpl userService;
+    @InjectMocks
+    private TokenServiceImpl tokenService;
 
     @DisplayName("전화번호로 id를 조회한다")
     @Test
@@ -65,7 +67,7 @@ class UserServiceImplTest extends ServiceTest {
                 .withExpiresAt(new Date(System.currentTimeMillis()))
                 .withClaim("id", Constants.test_user_1_id)
                 .sign(Algorithm.HMAC512("secret"));
-        assertThat(userService.getUserId("Bearer " + jwt)).isEqualTo(Constants.test_user_1_id);
+        assertThat(tokenService.getUserId("Bearer " + jwt)).isEqualTo(Constants.test_user_1_id);
     }
 
     @DisplayName("id로 회원 정보를 반환한다")


### PR DESCRIPTION
### 개요
access token 갱신 기능 구현

---

### 작업 사항
- access token 갱신 기능 구현
- refresh token을 확인하여 신규로 발급한 access token을 반환해주는 부분만 구현
- 세부 정책 확립 이후에 수정 필요, 또한 토큰을 신규로 발급하는 로직은 구현하지 않았음. 차후에 구현 필요.
- token에서 userId를 받아오는 메소드를 userService -> tokenService로 변경
- 테스트 코드 작성 및 수정 필요한 부분 수정, 그러나 의존하고 있는 메소드 중에서 개발이 덜된 메소드들이 있으므로 서비스계층 테스트 코드는 보류함.